### PR TITLE
Add previews for saved maps and display selected map name in menu

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,4 +68,7 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation("androidx.datastore:datastore-preferences:1.1.7")
+    implementation("com.google.code.gson:gson:2.13.2")
 }

--- a/app/src/main/java/com/example/wappo_game/domain/DomainModels.kt
+++ b/app/src/main/java/com/example/wappo_game/domain/DomainModels.kt
@@ -27,20 +27,17 @@ data class GameState(
     val walls: Set<Pair<Pos, Pos>> = emptySet(),
     val enemyFrozenTurns: Int = 0,
     val turn: Turn = Turn.PLAYER,
-    val result: GameResult = GameResult.Ongoing,
-    val playerMoves: Int = 0
+    @Transient val result: GameResult = GameResult.Ongoing,
+    val playerMoves: Int = 0,
+    val name: String = "Custom Map",
+    val initialPlayerPos: Pos = playerPos,
+    val initialEnemyPos: Pos = enemyPos
 ) {
     fun tileAt(p: Pos): Tile? = tiles.find { it.pos == p }
     fun inBounds(p: Pos) = p.r in 0 until rows && p.c in 0 until cols
 
     fun isBlocked(a: Pos, b: Pos): Boolean = (a to b) in walls || (b to a) in walls
 
-    fun canMove(from: Pos, to: Pos): Boolean {
-        if (!inBounds(to)) return false
-        if (from.manhattan(to) != 1) return false
-        if (isBlocked(from, to)) return false
-        return true
-    }
 }
 
 fun createDefaultGameState(): GameState {
@@ -79,12 +76,18 @@ fun createDefaultGameState(): GameState {
         Pos(4, 4) to Pos(4, 5)
     )
 
+    val initialPlayerPos = Pos(0, 0)
+    val initialEnemyPos = Pos(0, 5)
+
     return GameState(
         rows = rows,
         cols = cols,
         tiles = tiles,
         playerPos = Pos(0, 0),
         enemyPos = Pos(0, 5),
-        walls = walls
+        walls = walls,
+        name = "Default Map",
+        initialPlayerPos = initialPlayerPos,
+        initialEnemyPos = initialEnemyPos
     )
 }

--- a/app/src/main/java/com/example/wappo_game/presentation/MapsScreen.kt
+++ b/app/src/main/java/com/example/wappo_game/presentation/MapsScreen.kt
@@ -1,0 +1,133 @@
+package com.example.wappo_game.presentation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.wappo_game.domain.GameState
+import com.example.wappo_game.ui.BoardPreview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MapsScreen(
+    viewModel: GameViewModel,
+    onBack: () -> Unit,
+    onLoadMap: (GameState) -> Unit
+) {
+    val maps = viewModel.savedMaps.collectAsState().value
+    var showClearDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Saved Maps") }) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(12.dp)
+                .fillMaxSize()
+        ) {
+            if (maps.isEmpty()) {
+                Text("No saved maps yet", modifier = Modifier.padding(8.dp))
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f)) {
+                    items(maps) { map ->
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onLoadMap(map) }
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                BoardPreview(
+                                    state = map,
+                                    sizeDp = 140.dp
+                                )
+
+                                Box(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 12.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = map.name,
+                                        fontSize = 18.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        maxLines = 2
+                                    )
+                                }
+
+                                IconButton(
+                                    onClick = { viewModel.deleteMap(map.name) },
+                                    modifier = Modifier.size(40.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.Delete,
+                                        contentDescription = "Delete",
+                                        modifier = Modifier.size(32.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Button(onClick = onBack) {
+                    Text("Back")
+                }
+
+                Button(onClick = { showClearDialog = true }) {
+                    Text("Clear All")
+                }
+            }
+        }
+
+        if (showClearDialog) {
+            AlertDialog(
+                onDismissRequest = { showClearDialog = false },
+                title = { Text("Confirm") },
+                text = { Text("Are you sure you want to delete all saved maps?") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            viewModel.clearAllMaps()
+                            showClearDialog = false
+                        }
+                    ) {
+                        Text("Yes")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearDialog = false }) {
+                        Text("No")
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/wappo_game/presentation/MenuScreen.kt
+++ b/app/src/main/java/com/example/wappo_game/presentation/MenuScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.wappo_game.domain.GameState
 import com.example.wappo_game.ui.BoardPreview
 
@@ -16,27 +17,45 @@ fun MenuScreen(
     onPlayClick: () -> Unit,
     onEditorClick: () -> Unit,
     onExitClick: () -> Unit,
+    onMapsClick: () -> Unit,
     previewState: GameState? = null
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.height(56.dp))
-        Text("Wappo-like Game", modifier = Modifier.padding(8.dp))
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(36.dp))
+
+        Text(
+            text = "Wappo-like Game",
+            fontSize = 36.sp,
+            fontWeight = androidx.compose.ui.text.font.FontWeight.ExtraBold
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
 
         previewState?.let {
-            // show small preview
+            Text(
+                text = it.name,
+                fontSize = 24.sp,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+
             Box(modifier = Modifier.padding(8.dp)) {
                 BoardPreview(it, sizeDp = 200.dp)
             }
-            Spacer(modifier = Modifier.height(12.dp))
+
+            Spacer(modifier = Modifier.height(16.dp))
         }
 
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             Button(onClick = onPlayClick) { Text("Play") }
             Button(onClick = onEditorClick) { Text("Editor") }
+            Button(onClick = onMapsClick) { Text("Saved Maps") }
             Button(onClick = onExitClick) { Text("Exit") }
         }
     }

--- a/app/src/main/java/com/example/wappo_game/ui/EditorScreen.kt
+++ b/app/src/main/java/com/example/wappo_game/ui/EditorScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -14,12 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.wappo_game.domain.GameResult
-import com.example.wappo_game.domain.GameState
-import com.example.wappo_game.domain.Pos
-import com.example.wappo_game.domain.Tile
-import com.example.wappo_game.domain.TileType
-import com.example.wappo_game.domain.Turn
+import com.example.wappo_game.domain.*
 import kotlin.math.abs
 
 enum class EditorMode { TILES, WALLS, PLAYER_START, ENEMY_START }
@@ -52,8 +48,13 @@ fun EditorScreen(
 
     var mode by remember { mutableStateOf(EditorMode.TILES) }
 
+    // New: map name state (pre-fill from initialState.name if present)
+    var mapName by remember { mutableStateOf(initialState?.name ?: "") }
+
     Column(
-        modifier = Modifier.fillMaxSize().padding(12.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(8.dp))
@@ -67,6 +68,16 @@ fun EditorScreen(
             Button(onClick = { mode = EditorMode.PLAYER_START }) { Text("Set Player", fontSize = 11.sp) }
             Button(onClick = { mode = EditorMode.ENEMY_START }) { Text("Set Enemy", fontSize = 10.sp) }
         }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Map name input
+        OutlinedTextField(
+            value = mapName,
+            onValueChange = { mapName = it },
+            label = { Text("Map name (optional)") },
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)
+        )
 
         Spacer(modifier = Modifier.height(12.dp))
 
@@ -206,7 +217,8 @@ fun EditorScreen(
                     enemyFrozenTurns = 0,
                     turn = Turn.PLAYER,
                     result = GameResult.Ongoing,
-                    playerMoves = 0
+                    playerMoves = 0,
+                    name = mapName.ifBlank { "Custom Map" }
                 )
                 onSave(resultState)
                 onBack()

--- a/app/src/main/java/com/example/wappo_game/ui/GameScreen.kt
+++ b/app/src/main/java/com/example/wappo_game/ui/GameScreen.kt
@@ -42,7 +42,8 @@ fun GameScreen(vm: GameViewModel, onBackToMenu: () -> Unit) {
                 "Moves: ${state.playerMoves}  Result: ${state.result::class.simpleName}",
                 modifier = Modifier
                     .padding(vertical = 16.dp),
-                fontSize = 16.sp
+                fontSize = 24.sp,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
             )
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/example/wappo_game/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/wappo_game/ui/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.wappo_game.presentation.GameViewModel
+import com.example.wappo_game.presentation.MapsScreen
 import com.example.wappo_game.presentation.MenuScreen
 
 class MainActivity : ComponentActivity() {
@@ -46,7 +47,8 @@ fun AppNavHost(gameViewModel: GameViewModel) {
                 previewState = gameViewModel.state.value,
                 onPlayClick = { navController.navigate("game") },
                 onEditorClick = { navController.navigate("editor") },
-                onExitClick = { activity?.finish() }
+                onExitClick = { activity?.finish() },
+                onMapsClick = { navController.navigate("maps") } // если добавишь кнопку в меню
             )
         }
 
@@ -58,12 +60,25 @@ fun AppNavHost(gameViewModel: GameViewModel) {
             EditorScreen(
                 onBack = { navController.popBackStack() },
                 onSave = { newState ->
+                    // save to DataStore list and also set it as current playable map
+                    gameViewModel.saveCustomMap(newState)
                     gameViewModel.loadCustomMap(newState)
                     navController.navigate("game")
                 },
                 rows = 6,
                 cols = 6,
                 initialState = gameViewModel.state.value
+            )
+        }
+
+        composable("maps") {
+            MapsScreen(
+                viewModel = gameViewModel,
+                onBack = { navController.popBackStack() },
+                onLoadMap = { map ->
+                    gameViewModel.loadCustomMap(map)
+                    navController.navigate("game")
+                }
             )
         }
     }


### PR DESCRIPTION
This update introduces the following changes:

1. The list of saved maps now shows a preview of each map instead of a fixed 6x6 size.  
2. Map previews in the list are aligned to the left, map names are centered between the preview and the delete button, and the delete button is on the right.  
3. Map names are now styled with a larger, nicer font, with text wrapping to a second line if necessary.  
4. The main menu now displays the selected map with its name and a larger font under the game title.  
5. Overall UX improvements make selecting and viewing maps more intuitive and visually appealing.